### PR TITLE
Fixes #1: typo prevents config file from loading

### DIFF
--- a/cairo-dock.conf
+++ b/cairo-dock.conf
@@ -747,5 +747,4 @@ custom font=false
 
 #P+ Text font:
 font=Open Sans 10
-t:
 font=Open Sans 10


### PR DESCRIPTION
A typo in `cairo-dock.conf ` prevents `cairo_dock_open_key_file()` from loading this project's configuration file. This eventually causes cairo-dock to try and load an invalid image in `_load_active_window_indicator()`, since no valid image path can be extracted from a config file that was not loaded in memory. 


By the way, did you ensure your `current_theme/` directory matches your own theme? I believe you're running an outdated version.